### PR TITLE
Use 2017 version of CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 install:
     - sudo apt-get install -y frc-toolchain
-    - git clone https://github.com/intimitrons4604/tools-ci-cpp-build-script.git ~/tools-ci-cpp-build-script
+    - git clone --branch 2017.1.0 --depth 1 https://github.com/intimitrons4604/tools-ci-cpp-build-script.git ~/tools-ci-cpp-build-script
 
 script:
     - cd ~/tools-ci-cpp-build-script


### PR DESCRIPTION
Use the new 2017 compatible build script

Currently builds with the newest (default behaviour) versions of WPILib and CameraServer. If necessary later, we can fix the versions using the script's properties.